### PR TITLE
Add support for adding otherData

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ await pGraph(graph).run(); // returns a promise that will resolve when all the t
 profiler.output();
 ```
 
+You can also add any arbitrary key-value data to the profile json, using the function `setOtherData`. This can be useful in cases where you want to analyze the profile and need more information than what is available in the profile by default.
+
+```js
+const profiler = new Profiler({ concurrency });
+// Add events
+
+profiler.setOtherData("taskGraph", ["putOnShoes", "tieShoes"])
+```
+The profile json format is described [here](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview). If you haven't used `setOtherData` then json is array of events, otherwise it's an object with `traceEvents` and `otherData` properties.
+
 # Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a

--- a/change/p-profiler-2022-03-23-13-32-02-master.json
+++ b/change/p-profiler-2022-03-23-13-32-02-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add option to pass in otherData",
+  "packageName": "p-profiler",
+  "email": "\"ronakjain@microsoft.com\"",
+  "dependentChangeType": "patch",
+  "date": "2022-03-23T08:02:02.135Z"
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+    clearMocks: true,
+    collectCoverage: false,
+    collectCoverageFrom: ["src/**/*.ts", "!src/types/*.ts", "!**/node_modules/**"],
+    coverageDirectory: "coverage",
+    coverageProvider: "v8",
+    globals: {
+      "ts-jest": {
+        isolatedModules: true,
+      },
+    },
+    preset: "ts-jest",
+    testMatch: ["**/?(*.)+(spec|test).[tj]s?(x)"],
+    testPathIgnorePatterns: ["/node_modules/"],
+    transformIgnorePatterns: ["/node_modules/", "\\.pnp\\.[^\\/]+$"],
+    watchPathIgnorePatterns: ["/node_modules/"],
+  };
+  

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export default class Profiler {
    */
   output() {
     const profile = this.otherData ? { traceEvents: this.events, otherData: this.otherData } : this.events;
-    fs.writeFileSync(this.outputPath, JSON.stringify(profile, null, 2));
+    fs.writeFileSync(this.outputPath, JSON.stringify(profile));
     return this.outputPath;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,10 +33,13 @@ export default class Profiler {
   private outputPath: string;
   private threads: number[];
 
+  private otherData: any;
+
   constructor(opts: ProfilerOptions) {
     const { concurrency, outDir, prefix, customOutputPath } = opts;
 
     this.events = [];
+    this.otherData = undefined;
     this.outputPath =
       customOutputPath ||
       path.join(path.resolve(outDir || "."), getTimeBasedFilename(prefix));
@@ -77,11 +80,19 @@ export default class Profiler {
       });
   }
 
+  setOtherData(key: string, value: any) {
+    if (!this.otherData) {
+      this.otherData = {};
+    }
+    this.otherData[key] = value;
+  }
+
   /**
    * Writes out the profiler.json and returns the output path
    */
   output() {
-    fs.writeFileSync(this.outputPath, JSON.stringify(this.events));
+    const profile = this.otherData ? { traceEvents: this.events, otherData: this.otherData } : this.events;
+    fs.writeFileSync(this.outputPath, JSON.stringify(profile, null, 2));
     return this.outputPath;
   }
 }

--- a/tests/profiler.test.ts
+++ b/tests/profiler.test.ts
@@ -1,0 +1,33 @@
+import Profiler from '../src';
+import * as fs from 'fs';
+
+jest.mock("fs");
+
+describe("Profiler", () => {
+  const writeFileSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(() => {});
+  afterAll(() => {
+    jest.resetAllMocks();
+  })
+  it("should output empty array when no events are run", () => {
+    const profile = new Profiler({ concurrency: 4 });
+    profile.output();
+    const writeFileCalledWith = writeFileSpy.mock.calls[0][1];
+    expect(writeFileCalledWith).toBe("[]");
+  })
+  it("should output array with events when events are run", async () => {
+    const profile = new Profiler({ concurrency: 4 });
+    await profile.run(async () => {}, "test");
+    profile.output();
+    const writeFileCalledWith = JSON.parse(writeFileSpy.mock.calls[0][1].toString());
+    expect(writeFileCalledWith.map(event => event.name)).toContain("test");
+  })
+  it("should output object with traceEvents and otherData when events and otherData are given", async () => {
+    const profile = new Profiler({ concurrency: 4 });
+    await profile.run(async () => {}, "test");
+    profile.setOtherData("testKey", "testData");
+    profile.output();
+    const writeFileCalledWith = JSON.parse(writeFileSpy.mock.calls[0][1].toString());
+    expect(writeFileCalledWith.traceEvents.map(event => event.name)).toContain("test");
+    expect(writeFileCalledWith.otherData).toEqual({ "testKey": "testData" })
+  })
+})


### PR DESCRIPTION
Adding support for adding some additional data for analysis purposes. My use case - I want lage to output the targetGraph too in the profile json, so that we can analyze the build graph and figure out the critical path which impacts the build duration the most.

`otherData` is supported by trace event format described here https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#heading=h.uxpopqvbjezh. Tested the second profile format (with otherData) in edge and it seems to be working fine. 